### PR TITLE
Enhance analog clock page styling and navigation

### DIFF
--- a/analog_clock.html
+++ b/analog_clock.html
@@ -5,63 +5,318 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Analog Clock Reading Test</title>
 <style>
-  html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
-  .wrap { display: grid; grid-template-columns: 1fr 360px; gap: 24px; padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto; }
-  .panel { background:#f7f7f7; border:1px solid #e2e2e2; border-radius:16px; padding:16px; }
-  h1 { font-size: 20px; margin: 0 0 12px; }
-  .topbar { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
-  #timer { font-weight:700; font-variant-numeric: tabular-nums; padding:6px 10px; background:#fff; border:1px solid #e2e2e2; border-radius:10px; }
-  @media (max-width: 900px) { .wrap { grid-template-columns: 1fr; } }
+  :root {
+    color-scheme: light;
+    --bg: radial-gradient(circle at top, #f9fbff 0%, #e2ecff 35%, #d7e6ff 100%);
+    --panel-bg: #ffffff;
+    --panel-border: rgba(10, 56, 113, 0.12);
+    --text: #0b1930;
+    --muted: #56627a;
+    --accent: #0f62fe;
+    --accent-dark: #0b4bd8;
+    --shadow: 0 18px 45px rgba(15, 36, 84, 0.18);
+    --radius-xl: 22px;
+    --radius-md: 14px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    height: 100%;
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  header {
+    padding: 20px clamp(20px, 4vw, 48px) 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
+  header h1 {
+    font-size: clamp(22px, 3vw, 32px);
+    margin: 0;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  header a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  header a:hover,
+  header a:focus {
+    color: var(--accent-dark);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(20px, 4vw, 50px);
+  }
+
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(320px, 35vw, 360px);
+    gap: clamp(20px, 3vw, 36px);
+    width: min(1100px, 100%);
+  }
+
+  .panel {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius-xl);
+    padding: clamp(18px, 2vw, 26px);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(10px);
+  }
+
+  h1 {
+    font-size: clamp(20px, 2.4vw, 26px);
+    margin: 0 0 14px;
+  }
+
+  .panel p,
+  label,
+  .dial-note {
+    color: var(--muted);
+    font-size: 15px;
+  }
+
+  canvas#clock {
+    width: 100%;
+    height: auto;
+    max-width: 720px;
+    display: block;
+    margin: 0 auto;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  #timer {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    padding: 8px 14px;
+    background: rgba(15, 98, 254, 0.08);
+    border: 1px solid rgba(15, 98, 254, 0.25);
+    border-radius: var(--radius-md);
+  }
+
+  .dial-note {
+    margin-top: 18px;
+  }
+
+  .controls label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+    flex-wrap: wrap;
+  }
+
+  .row.actions {
+    margin-top: 6px;
+    gap: 10px;
+  }
+
+  select {
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(15, 36, 84, 0.25);
+    padding: 8px 14px;
+    font-size: 15px;
+    background-color: #fff;
+    min-width: 80px;
+  }
+
+  button {
+    border-radius: var(--radius-md);
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    padding: 9px 16px;
+    font-size: 15px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  }
+
+  button:hover {
+    transform: translateY(-1px);
+  }
+
+  button:active {
+    transform: translateY(0);
+  }
+
+  button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .primary {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 12px 20px rgba(15, 98, 254, 0.25);
+  }
+
+  .primary:hover,
+  .primary:focus {
+    background: var(--accent-dark);
+  }
+
+  .ghost {
+    background: rgba(15, 36, 84, 0.08);
+    color: var(--accent-dark);
+  }
+
+  .ghost:hover,
+  .ghost:focus {
+    background: rgba(15, 36, 84, 0.12);
+  }
+
+  .answer {
+    min-height: 32px;
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 18px;
+  }
+
+  .answer .ok { color: #0b8c58; }
+  .answer .bad { color: #c9184a; }
+
+  .score {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .card {
+    border-radius: var(--radius-md);
+    padding: 14px 16px;
+    background: rgba(15, 98, 254, 0.08);
+    color: var(--accent-dark);
+    text-align: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  .card div:first-child {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+
+  .metric {
+    font-size: 24px;
+    font-weight: 700;
+  }
+
+  footer {
+    text-align: center;
+    padding: 20px clamp(20px, 4vw, 40px) 40px;
+    color: var(--muted);
+    font-size: 14px;
+  }
+
+  @media (max-width: 900px) {
+    .wrap {
+      grid-template-columns: 1fr;
+    }
+
+    .panel {
+      padding: clamp(18px, 4vw, 28px);
+    }
+
+    header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
 </style>
 </head>
 <body>
-  <div class="wrap">
-    <div class="panel" id="clockPanel">
-      <h1>Read the Clock</h1>
-      <div class="topbar">
-        <button id="fs" class="ghost" title="Toggle full screen">Full Screen</button>
-        <span id="timer" aria-live="polite">00:00.0</span>
+  <header>
+    <h1>Analog Clock Reading Trainer</h1>
+    <a href="index.html">← Back to Main Activities</a>
+  </header>
+  <main>
+    <div class="wrap">
+      <div class="panel" id="clockPanel">
+        <h1>Read the Clock</h1>
+        <div class="topbar">
+          <button id="fs" class="ghost" title="Toggle full screen">Full Screen</button>
+          <span id="timer" aria-live="polite">00:00.0</span>
+        </div>
+        <canvas id="clock" width="800" height="800" aria-label="Analog clock showing a random time"></canvas>
+        <div class="dial-note">Only hour numbers are shown. Minute tick marks appear only in 1‑min mode. Hour and minute hands use strong contrast.</div>
       </div>
-      <canvas id="clock" width="800" height="800" aria-label="Analog clock showing a random time"></canvas>
-      <div class="dial-note">Only hour numbers are shown. Minute tick marks appear only in 1‑min mode. Hour and minute hands use strong contrast.</div>
+
+      <div class="panel controls" role="form" aria-label="Answer controls">
+        <h1>Your Answer</h1>
+
+        <label for="gran">Minute granularity</label>
+        <div class="row">
+          <select id="gran">
+            <option value="1">Exact minute (1‑min)</option>
+            <option value="5" selected>5‑minute steps</option>
+            <option value="15">15‑minute steps</option>
+          </select>
+          <button id="new" class="ghost">New time</button>
+        </div>
+
+        <label>Enter time</label>
+        <div class="row">
+          <select id="hour"></select>
+          <span>:</span>
+          <select id="minute"></select>
+        </div>
+
+        <div class="row actions">
+          <button id="check" class="primary">Check</button>
+          <button id="show" class="ghost">Show answer</button>
+          <button id="restart" class="ghost">Restart</button>
+        </div>
+
+        <div id="feedback" class="answer" aria-live="polite"></div>
+
+        <div class="score">
+          <div class="card"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
+          <div class="card"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
+          <div class="card"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
+          <div class="card"><div>Points</div><div id="scPoints" class="metric">0</div></div>
+        </div>
+      </div>
     </div>
-
-    <div class="panel controls" role="form" aria-label="Answer controls">
-      <h1>Your Answer</h1>
-
-      <label for="gran">Minute granularity</label>
-      <div class="row">
-        <select id="gran">
-          <option value="1">Exact minute (1‑min)</option>
-          <option value="5" selected>5‑minute steps</option>
-          <option value="15">15‑minute steps</option>
-        </select>
-        <button id="new" class="ghost">New time</button>
-      </div>
-
-      <label>Enter time</label>
-      <div class="row">
-        <select id="hour"></select>
-        <span>:</span>
-        <select id="minute"></select>
-      </div>
-
-      <div class="row" style="margin-top:10px; gap:10px;">
-        <button id="check" class="primary">Check</button>
-        <button id="show" class="ghost">Show answer</button>
-        <button id="restart" class="ghost">Restart</button>
-      </div>
-
-      <div id="feedback" class="answer" aria-live="polite"></div>
-
-      <div class="score">
-        <div class="card"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
-        <div class="card"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
-        <div class="card"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
-        <div class="card"><div>Points</div><div id="scPoints" class="metric">0</div></div>
-      </div>
-    </div>
-  </div>
+  </main>
+  <footer>
+    Practice reading analog time and track your progress with quick feedback.
+  </footer>
 
 <script>
 // ES5 only


### PR DESCRIPTION
## Summary
- refresh the analog clock trainer with a modern layout, responsive panels, and refined typography/colors
- add a persistent header/footer and a link back to the main activities page

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ee42599c008324899ce5aae8036317