### PR TITLE
Add speech recognition input for analog clock answers

### DIFF
--- a/analog_clock.html
+++ b/analog_clock.html
@@ -5,63 +5,350 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Analog Clock Reading Test</title>
 <style>
-  html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
-  .wrap { display: grid; grid-template-columns: 1fr 360px; gap: 24px; padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto; }
-  .panel { background:#f7f7f7; border:1px solid #e2e2e2; border-radius:16px; padding:16px; }
-  h1 { font-size: 20px; margin: 0 0 12px; }
-  .topbar { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
-  #timer { font-weight:700; font-variant-numeric: tabular-nums; padding:6px 10px; background:#fff; border:1px solid #e2e2e2; border-radius:10px; }
-  @media (max-width: 900px) { .wrap { grid-template-columns: 1fr; } }
+  :root {
+    color-scheme: light;
+    --bg: radial-gradient(circle at top, #f9fbff 0%, #e2ecff 35%, #d7e6ff 100%);
+    --panel-bg: #ffffff;
+    --panel-border: rgba(10, 56, 113, 0.12);
+    --text: #0b1930;
+    --muted: #56627a;
+    --accent: #0f62fe;
+    --accent-dark: #0b4bd8;
+    --shadow: 0 18px 45px rgba(15, 36, 84, 0.18);
+    --radius-xl: 22px;
+    --radius-md: 14px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    height: 100%;
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  header {
+    padding: 20px clamp(20px, 4vw, 48px) 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
+  header h1 {
+    font-size: clamp(22px, 3vw, 32px);
+    margin: 0;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  header a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  header a:hover,
+  header a:focus {
+    color: var(--accent-dark);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(20px, 4vw, 50px);
+  }
+
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(320px, 35vw, 360px);
+    gap: clamp(20px, 3vw, 36px);
+    width: min(1100px, 100%);
+  }
+
+  .panel {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius-xl);
+    padding: clamp(18px, 2vw, 26px);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(10px);
+  }
+
+  h1 {
+    font-size: clamp(20px, 2.4vw, 26px);
+    margin: 0 0 14px;
+  }
+
+  .panel p,
+  label,
+  .dial-note {
+    color: var(--muted);
+    font-size: 15px;
+  }
+
+  canvas#clock {
+    width: 100%;
+    height: auto;
+    max-width: 720px;
+    display: block;
+    margin: 0 auto;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  #timer {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    padding: 8px 14px;
+    background: rgba(15, 98, 254, 0.08);
+    border: 1px solid rgba(15, 98, 254, 0.25);
+    border-radius: var(--radius-md);
+  }
+
+  .dial-note {
+    margin-top: 18px;
+  }
+
+  .controls label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+    flex-wrap: wrap;
+  }
+
+  .row.actions {
+    margin-top: 6px;
+    gap: 10px;
+  }
+
+  .row.voice-row {
+    align-items: flex-start;
+    gap: 14px;
+  }
+
+  #voiceStatus {
+    flex: 1;
+    font-size: 14px;
+    color: var(--muted);
+    line-height: 1.4;
+    min-height: 24px;
+  }
+
+  #voiceStatus strong {
+    color: var(--text);
+  }
+
+  .voice-active {
+    background: rgba(15, 98, 254, 0.18);
+    color: var(--accent-dark);
+  }
+
+  select {
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(15, 36, 84, 0.25);
+    padding: 8px 14px;
+    font-size: 15px;
+    background-color: #fff;
+    min-width: 80px;
+  }
+
+  button {
+    border-radius: var(--radius-md);
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    padding: 9px 16px;
+    font-size: 15px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  }
+
+  button:hover {
+    transform: translateY(-1px);
+  }
+
+  button:active {
+    transform: translateY(0);
+  }
+
+  button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .primary {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 12px 20px rgba(15, 98, 254, 0.25);
+  }
+
+  .primary:hover,
+  .primary:focus {
+    background: var(--accent-dark);
+  }
+
+  .ghost {
+    background: rgba(15, 36, 84, 0.08);
+    color: var(--accent-dark);
+  }
+
+  .ghost:hover,
+  .ghost:focus {
+    background: rgba(15, 36, 84, 0.12);
+  }
+
+  .answer {
+    min-height: 32px;
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 18px;
+  }
+
+  .answer .ok { color: #0b8c58; }
+  .answer .bad { color: #c9184a; }
+
+  .score {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .card {
+    border-radius: var(--radius-md);
+    padding: 14px 16px;
+    background: rgba(15, 98, 254, 0.08);
+    color: var(--accent-dark);
+    text-align: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  .card div:first-child {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+
+  .metric {
+    font-size: 24px;
+    font-weight: 700;
+  }
+
+  footer {
+    text-align: center;
+    padding: 20px clamp(20px, 4vw, 40px) 40px;
+    color: var(--muted);
+    font-size: 14px;
+  }
+
+  @media (max-width: 900px) {
+    .wrap {
+      grid-template-columns: 1fr;
+    }
+
+    .panel {
+      padding: clamp(18px, 4vw, 28px);
+    }
+
+    header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
 </style>
 </head>
 <body>
-  <div class="wrap">
-    <div class="panel" id="clockPanel">
-      <h1>Read the Clock</h1>
-      <div class="topbar">
-        <button id="fs" class="ghost" title="Toggle full screen">Full Screen</button>
-        <span id="timer" aria-live="polite">00:00.0</span>
+  <header>
+    <h1>Analog Clock Reading Trainer</h1>
+    <a href="index.html">← Back to Main Activities</a>
+  </header>
+  <main>
+    <div class="wrap">
+      <div class="panel" id="clockPanel">
+        <h1>Read the Clock</h1>
+        <div class="topbar">
+          <button id="fs" class="ghost" title="Toggle full screen">Full Screen</button>
+          <span id="timer" aria-live="polite">00:00.0</span>
+        </div>
+        <canvas id="clock" width="800" height="800" aria-label="Analog clock showing a random time"></canvas>
+        <div class="dial-note">Only hour numbers are shown. Minute tick marks appear only in 1‑min mode. Hour and minute hands use strong contrast.</div>
       </div>
-      <canvas id="clock" width="800" height="800" aria-label="Analog clock showing a random time"></canvas>
-      <div class="dial-note">Only hour numbers are shown. Minute tick marks appear only in 1‑min mode. Hour and minute hands use strong contrast.</div>
+
+      <div class="panel controls" role="form" aria-label="Answer controls">
+        <h1>Your Answer</h1>
+
+        <label for="gran">Minute granularity</label>
+        <div class="row">
+          <select id="gran">
+            <option value="1">Exact minute (1‑min)</option>
+            <option value="5" selected>5‑minute steps</option>
+            <option value="15">15‑minute steps</option>
+          </select>
+          <button id="new" class="ghost">New time</button>
+        </div>
+
+        <label>Enter time</label>
+        <div class="row">
+          <select id="hour"></select>
+          <span>:</span>
+          <select id="minute"></select>
+        </div>
+
+        <div class="row voice-row" id="voiceRow">
+          <button id="voice" class="ghost" type="button">🎤 Speak Answer</button>
+          <div id="voiceStatus" aria-live="polite"></div>
+        </div>
+
+        <div class="row actions">
+          <button id="check" class="primary">Check</button>
+          <button id="show" class="ghost">Show answer</button>
+          <button id="restart" class="ghost">Restart</button>
+        </div>
+
+        <div id="feedback" class="answer" aria-live="polite"></div>
+
+        <div class="score">
+          <div class="card"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
+          <div class="card"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
+          <div class="card"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
+          <div class="card"><div>Points</div><div id="scPoints" class="metric">0</div></div>
+        </div>
+      </div>
     </div>
-
-    <div class="panel controls" role="form" aria-label="Answer controls">
-      <h1>Your Answer</h1>
-
-      <label for="gran">Minute granularity</label>
-      <div class="row">
-        <select id="gran">
-          <option value="1">Exact minute (1‑min)</option>
-          <option value="5" selected>5‑minute steps</option>
-          <option value="15">15‑minute steps</option>
-        </select>
-        <button id="new" class="ghost">New time</button>
-      </div>
-
-      <label>Enter time</label>
-      <div class="row">
-        <select id="hour"></select>
-        <span>:</span>
-        <select id="minute"></select>
-      </div>
-
-      <div class="row" style="margin-top:10px; gap:10px;">
-        <button id="check" class="primary">Check</button>
-        <button id="show" class="ghost">Show answer</button>
-        <button id="restart" class="ghost">Restart</button>
-      </div>
-
-      <div id="feedback" class="answer" aria-live="polite"></div>
-
-      <div class="score">
-        <div class="card"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
-        <div class="card"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
-        <div class="card"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
-        <div class="card"><div>Points</div><div id="scPoints" class="metric">0</div></div>
-      </div>
-    </div>
-  </div>
+  </main>
+  <footer>
+    Practice reading analog time and track your progress with quick feedback.
+  </footer>
 
 <script>
 // ES5 only
@@ -107,8 +394,14 @@
   var elSA = document.getElementById('scAttempts');
   var elSS = document.getElementById('scStreak');
   var elSP = document.getElementById('scPoints');
+  var elVoiceBtn = document.getElementById('voice');
+  var elVoiceStatus = document.getElementById('voiceStatus');
+  var elVoiceRow = document.getElementById('voiceRow');
 
   var WRONG_PENALTY = 10; // points deducted per wrong attempt
+  var SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  var recognition = null;
+  var listening = false;
 
   function setMinuteOptions(gran) {
     var i;
@@ -134,6 +427,324 @@
 
   function pad2(n) { return (n < 10 ? '0' : '') + n; }
 
+  function setVoiceStatus(text) {
+    if (elVoiceStatus) {
+      elVoiceStatus.textContent = text;
+    }
+  }
+
+  function clearVoiceStatus() {
+    if (!SpeechRecognition && elVoiceBtn && elVoiceBtn.disabled) { return; }
+    setVoiceStatus('');
+  }
+
+  function updateVoiceIdle() {
+    listening = false;
+    if (elVoiceBtn) {
+      elVoiceBtn.textContent = '🎤 Speak Answer';
+      elVoiceBtn.classList.remove('voice-active');
+    }
+  }
+
+  function startVoiceListening() {
+    if (!recognition || listening) { return; }
+    try {
+      recognition.start();
+      listening = true;
+      if (elVoiceBtn) {
+        elVoiceBtn.textContent = '⏹ Stop Listening';
+        elVoiceBtn.classList.add('voice-active');
+      }
+      setVoiceStatus('Listening… say the time like "three fifteen".');
+    } catch (err) {
+      updateVoiceIdle();
+      setVoiceStatus('Unable to access the microphone. Please try again.');
+    }
+  }
+
+  function stopVoiceListening() {
+    if (!recognition) { return; }
+    if (listening) {
+      listening = false;
+      try { recognition.stop(); }
+      catch (err) {
+        try { recognition.abort(); } catch (err2) {}
+      }
+    }
+    updateVoiceIdle();
+  }
+
+  function alignMinuteToGran(minute) {
+    var gran = state.gran || 1;
+    var maxStep = Math.floor(59 / gran);
+    var step = Math.round(minute / gran);
+    if (step > maxStep) { step = maxStep; }
+    if (step < 0) { step = 0; }
+    return step * gran;
+  }
+
+  function setSelectValue(select, value) {
+    if (!select) { return false; }
+    var options = select.options;
+    var i;
+    for (i = 0; i < options.length; i++) {
+      if (String(options[i].value) === String(value)) {
+        select.value = String(value);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function applyVoiceResult(result, transcript) {
+    if (!result) { return; }
+    var hour = result.hour;
+    var minute = result.minute;
+    if (!setSelectValue(elHour, hour)) {
+      elHour.value = String(((hour - 1 + 12) % 12) + 1);
+    }
+    var displayMinute = minute;
+    if (!setSelectValue(elMinute, minute)) {
+      var aligned = alignMinuteToGran(minute);
+      if (setSelectValue(elMinute, aligned)) {
+        displayMinute = aligned;
+      } else if (elMinute && elMinute.options.length) {
+        elMinute.selectedIndex = 0;
+        displayMinute = parseInt(elMinute.value, 10);
+      }
+    }
+    if (elMinute) {
+      displayMinute = parseInt(elMinute.value, 10);
+    }
+    setVoiceStatus('Heard "' + transcript + '" → ' + elHour.value + ':' + pad2(displayMinute));
+  }
+
+  function handleVoiceResult(event) {
+    if (!event || !event.results || !event.results[0]) { return; }
+    var alternatives = event.results[0];
+    var i;
+    var transcript;
+    var parsed = null;
+    for (i = 0; i < alternatives.length; i++) {
+      transcript = alternatives[i].transcript.trim();
+      parsed = parseSpeechTime(transcript);
+      if (parsed) {
+        applyVoiceResult(parsed, transcript);
+        break;
+      }
+    }
+    if (!parsed) {
+      transcript = alternatives[0].transcript.trim();
+      setVoiceStatus('Heard "' + transcript + '" but could not understand the time.');
+    }
+  }
+
+  function parseSpeechTime(raw) {
+    if (!raw) { return null; }
+    var text = String(raw).toLowerCase();
+    text = text.replace(/-/g, ' ');
+    text = text.replace(/[\.,!?]/g, ' ');
+    text = text.replace(/\b(?:o'clock|oclock)\b/g, ' ');
+    text = text.replace(/\b(?:the time is|time is|it is|it's|thats|that's)\b/g, ' ');
+    text = text.replace(/\b(?:p\.?m\.?|a\.?m\.?)\b/g, ' ');
+    text = text.replace(/\s+/g, ' ').trim();
+    if (!text) { return null; }
+
+    var colonMatch = text.match(/(\d{1,2})\s*:\s*(\d{1,2})/);
+    if (colonMatch) {
+      return finalizeTime(parseInt(colonMatch[1], 10), parseInt(colonMatch[2], 10));
+    }
+
+    var tokens = text.split(' ');
+    var numbers = extractNumbers(tokens);
+
+    var hasToKeyword = false;
+    var j;
+    for (j = 0; j < tokens.length; j++) {
+      if (tokens[j] === 'to' || tokens[j] === 'til' || tokens[j] === 'till') {
+        hasToKeyword = true;
+        break;
+      }
+    }
+
+    if (!numbers.length) {
+      var digitMatch = text.match(/(\d{1,2})\s+(\d{1,2})/);
+      if (digitMatch) {
+        return finalizeTime(parseInt(digitMatch[1], 10), parseInt(digitMatch[2], 10));
+      }
+      return null;
+    }
+
+    if (numbers.length === 1) {
+      return null;
+    }
+
+    if (hasToKeyword && numbers.length === 2 && numbers[0] < 60 && numbers[1] >= 1 && numbers[1] <= 12) {
+      var minutesValue = computeMinute([numbers[0]]);
+      if (minutesValue !== null) {
+        var hourValue = numbers[1] - 1;
+        if (hourValue <= 0) { hourValue += 12; }
+        return finalizeTime(hourValue, 60 - minutesValue);
+      }
+    }
+
+    return interpretNumbers(numbers);
+  }
+
+  function extractNumbers(tokens) {
+    var numbers = [];
+    var current = null;
+    var i;
+    var t;
+    var filler = {
+      'minutes': true, 'minute': true, 'hour': true, 'hours': true,
+      'past': true, 'after': true, 'before': true, 'to': true,
+      'and': true, 'exactly': true, 'around': true, 'almost': true,
+      'about': true, 'its': true, 'it': true, 's': true, 'that': true,
+      'thats': true, 'now': true, 'time': true, 'is': true, 'in': true,
+      'the': true, 'morning': true, 'evening': true, 'afternoon': true,
+      'night': true
+    };
+    for (i = 0; i < tokens.length; i++) {
+      t = tokens[i];
+      if (!t) { continue; }
+      if (/^\d{1,2}$/.test(t)) {
+        if (current !== null) { numbers.push(current); current = null; }
+        numbers.push(parseInt(t, 10));
+        continue;
+      }
+      if (filler[t]) {
+        if (current !== null) { numbers.push(current); current = null; }
+        continue;
+      }
+      if (t === 'noon') {
+        if (current !== null) { numbers.push(current); current = null; }
+        numbers.push(12);
+        continue;
+      }
+      if (t === 'midnight') {
+        if (current !== null) { numbers.push(current); current = null; }
+        numbers.push(12);
+        numbers.push(0);
+        continue;
+      }
+      if (t === 'oh' || t === 'o' || t === 'zero') {
+        if (current !== null) { numbers.push(current); current = null; }
+        numbers.push(0);
+        continue;
+      }
+      var tensValue = getTensValue(t);
+      if (tensValue !== null) {
+        if (current !== null && current >= 10) {
+          numbers.push(current);
+          current = null;
+        }
+        if (current === null) { current = 0; }
+        current += tensValue;
+        continue;
+      }
+      var numberValue = getNumberValue(t);
+      if (numberValue !== null) {
+        if (current !== null && numbers.length === 0 && current >= 10 && numberValue >= 10) {
+          numbers.push(current);
+          current = null;
+        }
+        if (current === null) { current = 0; }
+        current += numberValue;
+        continue;
+      }
+      if (current !== null) {
+        numbers.push(current);
+        current = null;
+      }
+    }
+    if (current !== null) {
+      numbers.push(current);
+    }
+    return numbers;
+  }
+
+  function getNumberValue(word) {
+    var map = {
+      'zero': 0, 'one': 1, 'two': 2, 'three': 3, 'four': 4,
+      'five': 5, 'six': 6, 'seven': 7, 'eight': 8, 'nine': 9,
+      'ten': 10, 'eleven': 11, 'twelve': 12, 'thirteen': 13,
+      'fourteen': 14, 'fifteen': 15, 'sixteen': 16, 'seventeen': 17,
+      'eighteen': 18, 'nineteen': 19, 'twenty': 20, 'thirty': 30,
+      'forty': 40, 'fifty': 50, 'quarter': 15, 'half': 30
+    };
+    return map.hasOwnProperty(word) ? map[word] : null;
+  }
+
+  function getTensValue(word) {
+    var map = {
+      'twenty': 20,
+      'thirty': 30,
+      'forty': 40,
+      'fifty': 50
+    };
+    return map.hasOwnProperty(word) ? map[word] : null;
+  }
+
+  function interpretNumbers(numbers) {
+    if (!numbers || numbers.length < 2) { return null; }
+    var hour = numbers[0];
+    var rest = numbers.slice(1);
+    var minute = null;
+
+    if (hour > 12 && rest.length) {
+      var possibleHour = rest[0];
+      var possibleMinute = computeMinute([hour].concat(rest.slice(1)));
+      if (possibleHour >= 1 && possibleHour <= 12 && possibleMinute !== null) {
+        return finalizeTime(possibleHour, possibleMinute);
+      }
+    }
+
+    minute = computeMinute(rest);
+    if (minute === null && rest.length >= 2) {
+      minute = computeMinute(rest.slice(1));
+    }
+    if (minute === null) {
+      return null;
+    }
+    return finalizeTime(hour, minute);
+  }
+
+  function computeMinute(rest) {
+    if (!rest || !rest.length) { return null; }
+    var first = rest[0];
+    if (first < 0) { return null; }
+    if (first < 60) {
+      var minute = first;
+      if (rest.length >= 2) {
+        var second = rest[1];
+        if (minute === 0 && second < 60) {
+          minute = second;
+        } else if (minute < 10 && second < 10) {
+          var combined = minute * 10 + second;
+          if (combined < 60) { minute = combined; }
+        } else if (minute % 10 === 0 && second < 10) {
+          var combined2 = minute + second;
+          if (combined2 < 60) { minute = combined2; }
+        }
+      }
+      return minute;
+    }
+    if (rest.length >= 2 && rest[1] < 60) {
+      return rest[1];
+    }
+    return null;
+  }
+
+  function finalizeTime(hour, minute) {
+    if (typeof hour !== 'number' || typeof minute !== 'number') { return null; }
+    if (hour <= 0) { hour = 12; }
+    hour = ((hour - 1) % 12 + 12) % 12 + 1;
+    if (minute < 0) { minute = 0; }
+    if (minute > 59) { minute = minute % 60; }
+    return { hour: hour, minute: minute };
+  }
+
   function randomTime(gran) {
     var h = 1 + Math.floor(Math.random() * 12);
     var steps = Math.floor(60 / gran);
@@ -156,6 +767,8 @@
   }
 
   function newQuestion() {
+    stopVoiceListening();
+    clearVoiceStatus();
     var t = randomTime(state.gran);
     state.hour = t.h;
     state.minute = t.m;
@@ -174,6 +787,7 @@
   }
 
   function checkAnswer() {
+    stopVoiceListening();
     var ah = parseInt(elHour.value, 10);
     var am = parseInt(elMinute.value, 10);
     var ok = (ah === state.hour && am === state.minute);
@@ -197,6 +811,7 @@
   }
 
   function showAnswer() {
+    stopVoiceListening();
     elFeedback.innerHTML = 'Answer: <strong>' + state.hour + ':' + pad2(state.minute) + '</strong>';
   }
 
@@ -343,6 +958,43 @@
   setMinuteOptions(state.gran);
   elGran.value = String(state.gran);
 
+  if (SpeechRecognition && elVoiceBtn && elVoiceRow) {
+    recognition = new SpeechRecognition();
+    recognition.lang = 'en-US';
+    recognition.interimResults = false;
+    recognition.maxAlternatives = 5;
+
+    recognition.addEventListener('result', function(event){
+      handleVoiceResult(event);
+    });
+
+    recognition.addEventListener('error', function(event){
+      var message = 'Listening error. Please try again.';
+      if (event && event.error === 'no-speech') {
+        message = 'No speech detected. Try speaking again.';
+      } else if (event && event.error === 'audio-capture') {
+        message = 'Microphone not available. Check your device.';
+      } else if (event && event.error === 'not-allowed') {
+        message = 'Microphone access was blocked.';
+      }
+      updateVoiceIdle();
+      setVoiceStatus(message);
+    });
+
+    recognition.addEventListener('end', function(){
+      updateVoiceIdle();
+    });
+
+    elVoiceBtn.addEventListener('click', function(){
+      if (listening) { stopVoiceListening(); }
+      else { startVoiceListening(); }
+    });
+  } else if (elVoiceRow && elVoiceBtn) {
+    elVoiceBtn.disabled = true;
+    elVoiceBtn.title = 'Voice recognition is not supported in this browser.';
+    setVoiceStatus('Voice recognition is not available in this browser.');
+  }
+
   // Events
   elGran.addEventListener('change', function(){
     var g = parseInt(elGran.value, 10);
@@ -368,6 +1020,8 @@
   // Restart
   function restartAll() {
     stopTimer();
+    stopVoiceListening();
+    clearVoiceStatus();
     state.correct = 0;
     state.attempts = 0;
     state.streak = 0;


### PR DESCRIPTION
## Summary
- add a speech recognition option to the analog clock trainer so learners can speak their answers
- interpret common spoken English time phrases and map them to the hour/minute selectors with clear status feedback
- disable the voice control gracefully when the browser lacks Web Speech support

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ee42599c008324899ce5aae8036317