### PR TITLE
Align algebra layout to top and improve touch drawing

### DIFF
--- a/algebra_practice/index.html
+++ b/algebra_practice/index.html
@@ -13,7 +13,7 @@
       background: transparent;
       min-height: 100vh;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
       padding: 12px;
       padding-top: calc(12px + env(safe-area-inset-top));
@@ -21,6 +21,7 @@
       padding-left: calc(12px + env(safe-area-inset-left));
       padding-right: calc(12px + env(safe-area-inset-right));
       overflow: hidden;
+      touch-action: none;
     }
     .app {
       width: min(520px, 100%);


### PR DESCRIPTION
## Summary
- move the algebra practice layout to the top of the viewport while keeping it centered horizontally
- disable default touch gestures on the page to prevent pointer cancellations when drawing on Android Chrome

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f061a29d7083248081041bc6b54d3c