### PR TITLE
Improve analog clock UI contrast and dial layout

### DIFF
--- a/analog_clock/index.html
+++ b/analog_clock/index.html
@@ -14,6 +14,14 @@
     --muted: #56627a;
     --accent: #0f62fe;
     --accent-dark: #0b4bd8;
+    --accent-soft: #e5edff;
+    --accent-strong: #062e7b;
+    --success: #0b8c58;
+    --danger: #c9184a;
+    --warning: #b25d00;
+    --warning-soft: #fff2d8;
+    --purple: #5d2fb8;
+    --purple-soft: #efe7ff;
     --shadow: 0 18px 45px rgba(15, 36, 84, 0.18);
     --radius-xl: 22px;
     --radius-md: 14px;
@@ -141,8 +149,7 @@
   }
 
   .panel p,
-  label,
-  .dial-note {
+  label {
     color: var(--muted);
     font-size: 15px;
   }
@@ -178,13 +185,10 @@
     font-weight: 700;
     font-variant-numeric: tabular-nums;
     padding: 8px 14px;
-    background: rgba(15, 98, 254, 0.08);
-    border: 1px solid rgba(15, 98, 254, 0.25);
+    background: var(--accent-soft);
+    border: 1px solid var(--accent-dark);
     border-radius: var(--radius-md);
-  }
-
-  .dial-note {
-    margin-top: 18px;
+    color: var(--accent-strong);
   }
 
   .controls label {
@@ -240,7 +244,9 @@
     font-size: 14px;
     color: var(--muted);
     line-height: 1.4;
-    min-height: 24px;
+    min-height: 48px;
+    display: flex;
+    align-items: center;
   }
 
   #voiceStatus strong {
@@ -268,7 +274,7 @@
     font-weight: 600;
     padding: 9px 16px;
     font-size: 15px;
-    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, color 0.15s ease;
   }
 
   button:hover {
@@ -319,16 +325,18 @@
   .primary:hover,
   .primary:focus {
     background: var(--accent-dark);
+    box-shadow: 0 14px 24px rgba(15, 98, 254, 0.3);
   }
 
   .ghost {
-    background: rgba(15, 36, 84, 0.08);
-    color: var(--accent-dark);
+    background: #fff;
+    color: var(--accent-strong);
+    border: 2px solid var(--accent);
   }
 
   .ghost:hover,
   .ghost:focus {
-    background: rgba(15, 36, 84, 0.12);
+    background: var(--accent-soft);
   }
 
   .answer {
@@ -338,8 +346,8 @@
     margin-bottom: 18px;
   }
 
-  .answer .ok { color: #0b8c58; }
-  .answer .bad { color: #c9184a; }
+  .answer .ok { color: var(--success); }
+  .answer .bad { color: var(--danger); }
 
   .score {
     display: grid;
@@ -349,11 +357,13 @@
 
   .card {
     border-radius: var(--radius-md);
-    padding: 14px 16px;
-    background: rgba(15, 98, 254, 0.08);
-    color: var(--accent-dark);
+    padding: 16px 18px;
+    background: var(--card-bg, var(--panel-bg));
+    border: 2px solid var(--card-border, rgba(15, 36, 84, 0.12));
+    color: var(--card-color, var(--accent-strong));
     text-align: center;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    box-shadow: var(--card-shadow, inset 0 1px 0 rgba(255, 255, 255, 0.65));
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .card div:first-child {
@@ -361,11 +371,41 @@
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 6px;
+    color: currentColor;
+    opacity: 0.72;
   }
 
   .metric {
-    font-size: 24px;
+    font-size: 26px;
     font-weight: 700;
+  }
+
+  .card--correct {
+    --card-bg: linear-gradient(135deg, rgba(11, 140, 88, 0.16), rgba(11, 140, 88, 0.05));
+    --card-border: rgba(11, 140, 88, 0.45);
+    --card-color: var(--success);
+    --card-shadow: 0 12px 26px rgba(11, 140, 88, 0.18);
+  }
+
+  .card--attempts {
+    --card-bg: linear-gradient(135deg, rgba(15, 98, 254, 0.16), rgba(15, 98, 254, 0.05));
+    --card-border: rgba(15, 98, 254, 0.4);
+    --card-color: var(--accent-strong);
+    --card-shadow: 0 12px 26px rgba(15, 98, 254, 0.16);
+  }
+
+  .card--streak {
+    --card-bg: linear-gradient(135deg, rgba(178, 93, 0, 0.18), rgba(178, 93, 0, 0.05));
+    --card-border: rgba(178, 93, 0, 0.45);
+    --card-color: var(--warning);
+    --card-shadow: 0 12px 26px rgba(178, 93, 0, 0.18);
+  }
+
+  .card--points {
+    --card-bg: linear-gradient(135deg, rgba(93, 47, 184, 0.18), rgba(93, 47, 184, 0.05));
+    --card-border: rgba(93, 47, 184, 0.45);
+    --card-color: var(--purple);
+    --card-shadow: 0 12px 26px rgba(93, 47, 184, 0.18);
   }
 
   footer {
@@ -468,7 +508,6 @@
           <span id="timer" aria-live="polite">00:00.0</span>
         </div>
         <canvas id="clock" width="800" height="800" aria-label="Analog clock showing a random time"></canvas>
-        <div class="dial-note">Open the options to adjust clock details. Minute tick marks appear only in 1‑min mode. Hour and minute hands use strong contrast.</div>
       </div>
 
       <div class="panel controls" role="form" aria-label="Answer controls">
@@ -503,10 +542,10 @@
         <div id="feedback" class="answer" aria-live="polite"></div>
 
         <div class="score">
-          <div class="card"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
-          <div class="card"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
-          <div class="card"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
-          <div class="card"><div>Points</div><div id="scPoints" class="metric">0</div></div>
+          <div class="card card--correct"><div>Correct</div><div id="scCorrect" class="metric">0</div></div>
+          <div class="card card--attempts"><div>Attempts</div><div id="scAttempts" class="metric">0</div></div>
+          <div class="card card--streak"><div>Streak</div><div id="scStreak" class="metric">0</div></div>
+          <div class="card card--points"><div>Points</div><div id="scPoints" class="metric">0</div></div>
         </div>
       </div>
     </div>
@@ -1292,8 +1331,8 @@
       var hTick;
       for (hTick = 0; hTick < 12; hTick++) {
         var angH = (Math.PI / 6) * hTick;
-        var innerH = r * 0.74;
-        var outerH = r * 0.94;
+        var innerH = r * 0.84;
+        var outerH = r * 0.96;
         ctx.beginPath();
         ctx.moveTo(innerH * Math.cos(angH), innerH * Math.sin(angH));
         ctx.lineTo(outerH * Math.cos(angH), outerH * Math.sin(angH));
@@ -1307,8 +1346,8 @@
         for (i = 0; i < 60; i++) {
           if (i % 5 === 0) { continue; }
           var ang = (Math.PI / 30) * i;
-          var inner = r * 0.88;
-          var outer = r * 0.96;
+          var inner = r * 0.9;
+          var outer = r * 0.97;
           ctx.beginPath();
           ctx.moveTo(inner * Math.cos(ang), inner * Math.sin(ang));
           ctx.lineTo(outer * Math.cos(ang), outer * Math.sin(ang));
@@ -1328,7 +1367,7 @@
       var n;
       for (n = 1; n <= 12; n++) {
         var angN = (Math.PI / 6) * (n - 3);
-        var nr = r * 0.78;
+        var nr = r * 0.76;
         var x = nr * Math.cos(angN);
         var y = nr * Math.sin(angN);
         ctx.fillText(String(n), x, y);


### PR DESCRIPTION
## Summary
- add higher-contrast button, timer, and score card styling for better readability
- stabilize voice status area height and remove outdated instructional copy from the clock panel
- shorten dial tick marks and adjust number placement to prevent overlaps on the analog face
- color-code the correct, attempts, streak, and points cards for clearer differentiation

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2e198f81483248a8cd5752c0bd198