### PR TITLE
Fix Solid Net Explorer three.js loading and folding animation

### DIFF
--- a/solid_nets/index.html
+++ b/solid_nets/index.html
@@ -299,8 +299,14 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <script type="module" crossorigin src="https://unpkg.com/three@0.160.0/build/three.module.js"></script>
-  <script type="module" crossorigin src="https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+        "three/examples/jsm/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+      }
+    }
+  </script>
 </head>
 <body>
   <header>
@@ -359,8 +365,8 @@
   </footer>
 
   <script type="module">
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+    import * as THREE from 'three';
+    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
     const solidSelect = document.getElementById('solid-select');
     const netSelect = document.getElementById('net-select');
@@ -640,7 +646,7 @@
       netGroup.children.forEach(mesh => {
         const { flatPosition, flatQuaternion, foldedPosition, foldedQuaternion, name } = mesh.userData;
         mesh.position.copy(flatPosition.clone().lerp(foldedPosition, t));
-        THREE.Quaternion.slerp(flatQuaternion, foldedQuaternion, mesh.quaternion, t);
+        mesh.quaternion.copy(flatQuaternion).slerp(foldedQuaternion, t);
 
         if (currentNet && !currentNet.valid && currentNet.overlapFaces && t > 0.75) {
           const isOverlap = currentNet.overlapFaces.includes(name);


### PR DESCRIPTION
## Summary
- add an import map so three.js and its examples resolve correctly in the browser
- update the Solid Net Explorer module imports and quaternion interpolation so folding renders properly

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68f4438ee6a083249997856bb348d080